### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "make -f src/Makefile.simple && ./mkrand -h"

--- a/README.md
+++ b/README.md
@@ -7,13 +7,8 @@ A Digital Random Bit Generator
 
 An ergodic process, MKRAND produces a statistically homogenous random bitstream. This bitstream is rendered in various formats.
 
-
-**Updates since TA-1:**
-* Streaming, use -n 0
-* Profiler now calculates Shannon entropy (H)
-* Bit-pack vectors for binary file output format
-* Automake
   
+[![Run on Repl.it](https://repl.it/badge/github/unozerocode/MKRAND)](https://repl.it/github/unozerocode/MKRAND)
 
 [![Build Status](https://secure.travis-ci.org/mknight-tag/MKRAND.png?branch=master)](https://travis-ci.org/mknight-tag/MKRAND)
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@unozerocode/MKRAND).